### PR TITLE
fix: Validate Config Form Against Submit Null Values

### DIFF
--- a/e2e-tests/authenticated/assetConfiguration.spec.ts
+++ b/e2e-tests/authenticated/assetConfiguration.spec.ts
@@ -100,3 +100,38 @@ test('Update asset configuration', async ({ page }) => {
 		nod: [DataModules.GNSS, DataModules.NeigboringCellMeasurements],
 	})
 })
+
+test("Should check 'update' button to be disabled when form is fill with null values", async ({
+	page,
+}) => {
+	await page.click('header[role="button"]:has-text("Settings")')
+
+	// expect 'update' button to be disable be default
+	await expect(
+		page.locator('#asset-settings-form >> footer >> button'),
+	).toBeDisabled()
+
+	// update Active Wait Time with value
+	await page.fill('#actwt', (400).toString())
+
+	// expect 'update' button to be enable
+	await expect(
+		page.locator('#asset-settings-form >> footer >> button'),
+	).not.toBeDisabled()
+
+	// update Active Wait Time with wrong value
+	await page.fill('#actwt', '')
+
+	// expect update button to be disabled
+	await expect(
+		page.locator('#asset-settings-form >> footer >> button'),
+	).toBeDisabled()
+
+	// update Active Wait Time with correct value
+	await page.fill('#actwt', (400).toString())
+
+	// expect update to be enable
+	await expect(
+		page.locator('#asset-settings-form >> footer >> button'),
+	).not.toBeDisabled()
+})

--- a/src/components/Asset/Settings/Settings.tsx
+++ b/src/components/Asset/Settings/Settings.tsx
@@ -1,6 +1,5 @@
 import type { Static } from '@sinclair/typebox'
-import type { AssetConfig } from 'asset/asset'
-import { DataModules } from 'asset/asset'
+import { AssetConfig, DataModules } from 'asset/asset'
 import { defaultConfig } from 'asset/defaultConfig'
 import cx from 'classnames'
 import { NumberConfigSetting } from 'components/Asset/Settings/NumberConfigSetting'
@@ -11,6 +10,7 @@ import { NoData } from 'components/NoData'
 import equal from 'fast-deep-equal'
 import { useAsset } from 'hooks/useAsset'
 import { useEffect, useState } from 'react'
+import { validateWithJSONSchema } from 'utils/validateWithJSONSchema'
 
 const MAX_INT32 = 2147483647
 
@@ -74,6 +74,10 @@ const SettingsUI = ({
 		newDesiredConfig.act !== undefined
 			? newDesiredConfig.act === true
 			: reportedConfig?.act === true
+
+	const isNewDesiredConfigValid = !(
+		'errors' in validateWithJSONSchema(AssetConfig)(newDesiredConfig)
+	)
 
 	return (
 		<form className={styles.SettingsForm} id="asset-settings-form">
@@ -434,7 +438,7 @@ const SettingsUI = ({
 				<button
 					type="button"
 					className={'btn btn-primary'}
-					disabled={!hasChanges}
+					disabled={!hasChanges || !isNewDesiredConfigValid}
 					onClick={() => {
 						update({
 							cfg: newDesiredConfig,


### PR DESCRIPTION
Avoid submitting values that are not considered correct for the configuration validation scheme by disabling the Submit button when validation criteria are not met