### PR TITLE
fix: update of configurations for walking and parcel tracking

### DIFF
--- a/src/asset/config.ts
+++ b/src/asset/config.ts
@@ -25,26 +25,26 @@ export const presetConfigs: Record<
 		config: {
 			...defaultConfig,
 			mvres: 3600,
-			accito: 1200,
-			mvt: 21600,
-			accath: 10,
-			accith: 5,
+			accito: 300,
+			mvt: 86400,
+			accath: 11,
+			accith: 7,
 		},
 		label: 'Parcel tracking',
 		description:
-			'Use this if you want to track parcels. It records location every hour when not moving and every 20 minutes when on the move. The accelerometer is configured for motion in vehicles.',
+			'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	},
 	walking: {
 		config: {
 			...defaultConfig,
-			mvres: 300,
+			mvres: 180,
 			accito: 60,
 			mvt: 3600,
-			accath: 3,
-			accith: 1,
+			accath: 5,
+			accith: 4.5,
 		},
 		label: 'Walking',
 		description:
-			'Use this to track people activities like walking. It records location every hour when not moving and every 5 minutes when on the move. The accelerometer is configured for light motion, like walking.',
+			'Use this to track people activities like walking. It records location every hour when not moving and every 3 minutes when on the move. The accelerometer is configured for light motion, like walking.',
 	},
 }

--- a/src/components/Asset/Configuration/Presets.spec.tsx
+++ b/src/components/Asset/Configuration/Presets.spec.tsx
@@ -37,7 +37,7 @@ test('<Presets/>', async () => {
 	expect(walking.findOne('h5').content()).toEqual('Walking')
 
 	expect(walking.findOne('p').content()).toEqual(
-		'Use this to track people activities like walking. It records location every hour when not moving and every 5 minutes when on the move. The accelerometer is configured for light motion, like walking.',
+		'Use this to track people activities like walking. It records location every hour when not moving and every 3 minutes when on the move. The accelerometer is configured for light motion, like walking.',
 	)
 
 	walking.findOne('button').props.onClick()
@@ -49,7 +49,7 @@ test('<Presets/>', async () => {
 	expect(parcel.findOne('h5').content()).toEqual('Parcel tracking')
 
 	expect(parcel.findOne('p').content()).toEqual(
-		'Use this if you want to track parcels. It records location every hour when not moving and every 20 minutes when on the move. The accelerometer is configured for motion in vehicles.',
+		'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	)
 
 	parcel.findOne('button').props.onClick()


### PR DESCRIPTION
Update of new configs for the asset tracker, the config for parcel tracking could be tested better, but I have just based it off the idea that it does not trigger when I'm on the bus, but it is tracking when I am moving the thingy:91 around directly. I was thinking on bringing the thingy in my luggage on my next travel to see if this config works as intended, then I get to test it from "start" to "finish", but for now, this was the best I managed to test. closes #406 

