### PR TITLE
fix: update of configurations for walking and parcel tracking

### DIFF
--- a/e2e-tests/authenticated/configuration/configurationExplainer.spec.ts
+++ b/e2e-tests/authenticated/configuration/configurationExplainer.spec.ts
@@ -79,7 +79,7 @@ test('Should update the explainer configuration text in order of the field chang
 		.click()
 
 	// check config explainer with "Walking" preset config values
-	await checkMvresExplainerSentence(page, explainDuration(300))
+	await checkMvresExplainerSentence(page, explainDuration(180))
 	await checkAccitoExplainerSentence(page, explainDuration(60))
 	await checkMvtExplainerSentence(page, explainDuration(3600))
 
@@ -89,9 +89,19 @@ test('Should update the explainer configuration text in order of the field chang
 		.click()
 
 	// check config explainer with "Parcel" preset config values
-	await checkMvresExplainerSentence(page, explainDuration(3600))
-	await checkAccitoExplainerSentence(page, explainDuration(1200))
-	await checkMvtExplainerSentence(page, explainDuration(21600))
+	await checkMvresExplainerSentence(page, explainDuration(30))
+	await checkAccitoExplainerSentence(page, explainDuration(10))
+	await checkMvtExplainerSentence(page, explainDuration(86400))
+
+	// select Driving preset
+	await page
+		.locator('[id="asset:presets"] >> [data-test="driving"] >> button')
+		.click()
+
+	// check config explainer with "Driving" preset config values
+	await checkMvresExplainerSentence(page, explainDuration(60))
+	await checkAccitoExplainerSentence(page, explainDuration(30))
+	await checkMvtExplainerSentence(page, explainDuration(3600))
 
 	// fill form with other info
 	await page.fill('#mvres', (1000).toString())

--- a/src/asset/config.ts
+++ b/src/asset/config.ts
@@ -25,26 +25,26 @@ export const presetConfigs: Record<
 		config: {
 			...defaultConfig,
 			mvres: 3600,
-			accito: 1200,
-			mvt: 21600,
-			accath: 10,
-			accith: 5,
+			accito: 300,
+			mvt: 86400,
+			accath: 11,
+			accith: 7,
 		},
 		label: 'Parcel tracking',
 		description:
-			'Use this if you want to track parcels. It records location every hour when not moving and every 20 minutes when on the move. The accelerometer is configured for motion in vehicles.',
+			'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	},
 	walking: {
 		config: {
 			...defaultConfig,
-			mvres: 300,
+			mvres: 180,
 			accito: 60,
 			mvt: 3600,
-			accath: 3,
-			accith: 1,
+			accath: 5,
+			accith: 4.5,
 		},
 		label: 'Walking',
 		description:
-			'Use this to track people activities like walking. It records location every hour when not moving and every 5 minutes when on the move. The accelerometer is configured for light motion, like walking.',
+			'Use this to track people activities like walking. It records location every hour when not moving and every 3 minutes when on the move. The accelerometer is configured for light motion, like walking.',
 	},
 }

--- a/src/asset/config.ts
+++ b/src/asset/config.ts
@@ -58,6 +58,6 @@ export const presetConfigs: Record<
 		},
 		label: 'Driving',
 		description:
-			'Use this to track people activities like driving. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for driving.',
+			'Use this to track vehicles. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for vehicles.',
 	},
 }

--- a/src/asset/config.ts
+++ b/src/asset/config.ts
@@ -24,15 +24,15 @@ export const presetConfigs: Record<
 	parcel: {
 		config: {
 			...defaultConfig,
-			mvres: 3600,
-			accito: 300,
+			mvres: 30,
+			accito: 10,
 			mvt: 86400,
 			accath: 11,
 			accith: 7,
 		},
 		label: 'Parcel tracking',
 		description:
-			'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
+			'Use this if you want to track parcels. It records location every 24 hours when not moving and every 30 seconds when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	},
 	walking: {
 		config: {
@@ -46,5 +46,18 @@ export const presetConfigs: Record<
 		label: 'Walking',
 		description:
 			'Use this to track people activities like walking. It records location every hour when not moving and every 3 minutes when on the move. The accelerometer is configured for light motion, like walking.',
+	},
+	driving: {
+		config: {
+			...defaultConfig,
+			mvres: 60,
+			accito: 30,
+			mvt: 3600,
+			accath: 5,
+			accith: 4.5,
+		},
+		label: 'Driving',
+		description:
+			'Use this to track people activities like driving. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for driving.',
 	},
 }

--- a/src/components/Asset/Configuration/Presets.spec.tsx
+++ b/src/components/Asset/Configuration/Presets.spec.tsx
@@ -49,9 +49,17 @@ test('<Presets/>', async () => {
 	expect(parcel.findOne('h5').content()).toEqual('Parcel tracking')
 
 	expect(parcel.findOne('p').content()).toEqual(
-		'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
+		'Use this if you want to track parcels. It records location every 24 hours when not moving and every 30 seconds when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	)
 
 	parcel.findOne('button').props.onClick()
 	expect(setNewDesiredConfig).toHaveBeenCalledWith(presetConfigs.parcel.config)
+
+	//Use driving presets
+	const driving = isolated.findOne('[data-test=driving]')
+
+	expect(driving.findOne('h5').content()).toEqual('Driving')
+	expect(driving.findOne('p').content()).toEqual(
+		'Use this to track people activities like driving. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for driving.',
+	)
 })

--- a/src/components/Asset/Configuration/Presets.spec.tsx
+++ b/src/components/Asset/Configuration/Presets.spec.tsx
@@ -60,6 +60,6 @@ test('<Presets/>', async () => {
 
 	expect(driving.findOne('h5').content()).toEqual('Driving')
 	expect(driving.findOne('p').content()).toEqual(
-		'Use this to track people activities like driving. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for driving.',
+		'Use this to track vehicles. It records location every hour when not moving and every 1 minutes when on the move. The accelerometer is configured for vehicles.',
 	)
 })

--- a/src/components/Asset/Configuration/Presets.spec.tsx
+++ b/src/components/Asset/Configuration/Presets.spec.tsx
@@ -37,7 +37,7 @@ test('<Presets/>', async () => {
 	expect(walking.findOne('h5').content()).toEqual('Walking')
 
 	expect(walking.findOne('p').content()).toEqual(
-		'Use this to track people activities like walking. It records location every hour when not moving and every 5 minutes when on the move. The accelerometer is configured for light motion, like walking.',
+		'Use this to track people activities like walking. It records location every hour when not moving and every 3 minutes when on the move. The accelerometer is configured for light motion, like walking.',
 	)
 
 	walking.findOne('button').props.onClick()
@@ -49,7 +49,7 @@ test('<Presets/>', async () => {
 	expect(parcel.findOne('h5').content()).toEqual('Parcel tracking')
 
 	expect(parcel.findOne('p').content()).toEqual(
-		'Use this if you want to track parcels. It records location every hour when not moving and every 20 minutes when on the move. The accelerometer is configured for motion in vehicles.',
+		'Use this if you want to track parcels. It records location every 24 hours when not moving and every hour when on the move. The accelerometer is configured for tracking movement of handling packages, but avoids tracking motion in vehicle.',
 	)
 
 	parcel.findOne('button').props.onClick()


### PR DESCRIPTION
Update of new configs for the asset tracker, the config for parcel tracking could be tested better, but I have just based it off the idea that it does not trigger when I'm on the bus, but it is tracking when I am moving the thingy:91 around directly. I was thinking on bringing the thingy in my luggage on my next travel to see if this config works as intended, then I get to test it from "start" to "finish", but for now, this was the best I managed to test. closes #406 